### PR TITLE
:bug: Fix issue when call invalidateLayout()

### DIFF
--- a/Sources/CollectionViewSlantedLayout.swift
+++ b/Sources/CollectionViewSlantedLayout.swift
@@ -289,5 +289,11 @@ extension CollectionViewSlantedLayout {
     override open func layoutAttributesForItem(at indexPath: IndexPath) -> CollectionViewSlantedLayoutAttributes? {
         return cachedAttributes[indexPath.item]
     }
+ 
+    /// :nodoc:
+    override open func invalidateLayout() {
+        super.invalidateLayout()
+        self.cachedAttributes.removeAll()
+    }
 
 }


### PR DESCRIPTION
Fixed an error that could appear when updating the list when cells are added or removed.

This error is : 
```
[CollectionView] Layout attributes <CollectionViewSlantedLayout.CollectionViewSlantedLayoutAttributes: 0x7ff1035113c0> index path: (<NSIndexPath: 0xbcd26c36f94746f0> {length = 2, path = 0 - 3}); frame = (0 603; 414 275); zIndex = 3;  were received from the layout <CollectionViewSlantedLayout.CollectionViewSlantedLayout: 0x7ff1035148a0> but are not valid for the data source counts. Attributes will be ignored.
```